### PR TITLE
Fix dependency error in nessus::config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -20,6 +20,7 @@ class nessus::config inherits nessus {
       path    => [ '/bin', '/opt/nessus/bin', '/opt/nessus/sbin' ],
       command => "${activate_command} && touch /opt/nessus/var/nessus/security_center_activated",
       creates => '/opt/nessus/var/nessus/security_center_activated',
+      notify  => Exec['Wait 60 seconds for Nessus activation'],
     }
   } else {
     if ! $::nessus_activation_code {
@@ -34,7 +35,8 @@ class nessus::config inherits nessus {
 
         exec { 'Activate Nessus':
           path    => [ '/opt/nessus/bin', '/opt/nessus/sbin' ],
-          command => $activate_command
+          command => $activate_command,
+          notify  => Exec['Wait 60 seconds for Nessus activation'],
         }
       }
     }
@@ -45,7 +47,6 @@ class nessus::config inherits nessus {
     path        => [ '/bin' ],
     command     => 'sleep 60',
     refreshonly => true,
-    subscribe   => Exec['Activate Nessus'],
     notify      => Service[$service_name],
   }
 

--- a/spec/classes/nessus_spec.rb
+++ b/spec/classes/nessus_spec.rb
@@ -43,7 +43,11 @@ describe 'nessus' do
     end
 
     describe 'nessus::config' do
-      context 'without nessus_activation_code' do
+      context 'without nessus_activation_code or supplied activation_code' do
+        it { should compile }
+      end
+
+      context 'without nessus_activation_code and with supplied activation_code' do
         let(:params) {{
           :activation_code => 'xxxx-xxxx-xxxx-xxxx'
         }}
@@ -66,7 +70,6 @@ describe 'nessus' do
         }}
 
         it { should_not contain_exec('Activate Nessus') }
-
       end
 
       context 'with security_center' do


### PR DESCRIPTION
If Nessus is already activated and $security_center is false, then running this class will trigger
the following error:

    Error: Could not find dependency Exec[Activate Nessus] for Exec[Wait 60 seconds for Nessus activation]